### PR TITLE
Fixed "@class module" tag and minor HTML layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ HTML_LUAS= src/luadoc/doclet/html/file.lp \
 	src/luadoc/doclet/html/luadoc.css \
 	src/luadoc/doclet/html/menu.lp \
 	src/luadoc/doclet/html/module.lp \
-	src/luadoc/doclet/html/table.lp
+	src/luadoc/doclet/html/table.lp \
+	src/luadoc/doclet/html/module_or_file.lp
 TAGLET_LUAS= src/luadoc/taglet/standard.lua
 STANDARD_LUAS= src/luadoc/taglet/standard/tags.lua
 

--- a/src/luadoc/doclet/html/file.lp
+++ b/src/luadoc/doclet/html/file.lp
@@ -46,6 +46,18 @@
 <p><small><b>Release:</b> <%=file_doc.release%></small></p>
 <%end%>
 
+<%if #file_doc.tables > 0 then%>
+<h2>Tables</h2>
+<table class="table_list">
+<%for _, tab_name in ipairs(file_doc.tables) do%>
+	<tr>
+	<td class="name" nowrap><a href="#<%=tab_name%>"><%=tab_name%></a></td>
+	<td class="summary"><%=file_doc.tables[tab_name].summary%></td>
+	</tr>
+<%end%>
+</table>
+<%end%>
+
 <%if #file_doc.functions > 0 then%>
 <h2>Functions</h2>
 <table class="function_list">
@@ -59,34 +71,8 @@
 </table>
 <%end%>
 
-
-<%if #file_doc.tables > 0 then%>
-<h2>Tables</h2>
-<table class="table_list">
-<%for _, tab_name in ipairs(file_doc.tables) do%>
-	<tr>
-	<td class="name" nowrap><a href="#<%=tab_name%>"><%=tab_name%></a></td>
-	<td class="summary"><%=file_doc.tables[tab_name].summary%></td>
-	</tr>
-<%end%>
-</table>
-<%end%>
-
-
 <br/>
 <br/>
-
-
-
-<%if #file_doc.functions > 0 then%>
-<h2><a name="functions"></a>Functions</h2>
-<dl class="function">
-<%for _, func_name in ipairs(file_doc.functions) do%>
-<%=luadoc.doclet.html.include("function.lp", { doc=doc, file_doc=file_doc, func=file_doc.functions[func_name] })%>
-<%end%>
-</dl>
-<%end%>
-
 
 <%if #file_doc.tables > 0 then%>
 <h2><a name="tables"></a>Tables</h2>
@@ -97,7 +83,14 @@
 </dl>
 <%end%>
 
-
+<%if #file_doc.functions > 0 then%>
+<h2><a name="functions"></a>Functions</h2>
+<dl class="function">
+<%for _, func_name in ipairs(file_doc.functions) do%>
+<%=luadoc.doclet.html.include("function.lp", { doc=doc, file_doc=file_doc, func=file_doc.functions[func_name] })%>
+<%end%>
+</dl>
+<%end%>
 
 </div> <!-- id="content" -->
 

--- a/src/luadoc/doclet/html/file.lp
+++ b/src/luadoc/doclet/html/file.lp
@@ -27,61 +27,10 @@
 
 <h1>File <code><%=file_doc.name%></code></h1>
 
-<%if file_doc.description then%>
-<p><%=file_doc.description%></p>
-<%end%>
-<%if file_doc.author then%>
-<p><b><%= #file_doc.author>1 and "Authors" or "Author" %>:</b>
-<table class="authors_list">
-<%for _, author in ipairs(file_doc.author) do%>
-	<tr><td class="name"><%= author %></td></tr>
-<%end%>
-</table>
-</p>
-<%end%>
-<%if file_doc.copyright then%>
-<p>Copyright &copy;<%=file_doc.copyright%></p>
-<%end%>
-<%if file_doc.release then%>
-<p><small><b>Release:</b> <%=file_doc.release%></small></p>
-<%end%>
-
-<%if #file_doc.tables > 0 then%>
-<h2>Tables</h2>
-<table class="table_list">
-<%for _, tab_name in ipairs(file_doc.tables) do%>
-	<tr>
-	<td class="name" nowrap><a href="#<%=tab_name%>"><%=tab_name%></a></td>
-	<td class="summary"><%=file_doc.tables[tab_name].summary%></td>
-	</tr>
-<%end%>
-</table>
-<%end%>
-
-<%if #file_doc.functions > 0 then%>
-<h2>Functions</h2>
-<table class="function_list">
-<%for _, func_name in ipairs(file_doc.functions) do
-  local func_data = file_doc.functions[func_name]%>
-	<tr>
-	<td class="name" nowrap><%=func_data.private and "local " or ""%><a href="#<%=func_name%>"><%=func_name%></a>&nbsp;(<%=table.concat(func_data.param, ", ")%>)</td>
-	<td class="summary"><%=func_data.summary%></td>
-	</tr>
-<%end%>
-</table>
-<%end%>
-
-<br/>
-<br/>
-
-<%if #file_doc.tables > 0 then%>
-<h2><a name="tables"></a>Tables</h2>
-<dl class="table">
-<%for _, tab_name in ipairs(file_doc.tables) do%>
-<%=luadoc.doclet.html.include("table.lp", { doc=doc, file_doc=file_doc, tab=file_doc.tables[tab_name] })%>
-<%end%>
-</dl>
-<%end%>
+<%=luadoc.doclet.html.include("module_or_file.lp", { 
+    about=file_doc,
+    functions=file_doc.functions, file_doc=file_doc, tables=file_doc.tables 
+})%>
 
 <%if #file_doc.functions > 0 then%>
 <h2><a name="functions"></a>Functions</h2>

--- a/src/luadoc/doclet/html/function.lp
+++ b/src/luadoc/doclet/html/function.lp
@@ -23,9 +23,10 @@ end
 </ul>
 <%end%>
 
-
+<%if func.usage then%>
+<div>
 <%if type(func.usage) == "string" then%>
-<h3>Usage:</h3>
+<h3 class="inline-block">Usage:</h3>
 <%=func.usage%>
 <%elseif type(func.usage) == "table" then%>
 <h3>Usage</h3>
@@ -35,9 +36,13 @@ end
 	<%end%>
 </ul>
 <%end%>
+</div>
+<%end%>
 
+<%if func.ret then%>
+<div>
 <%if type(func.ret) == "string" then%>
-<h3>Return value:</h3>
+<h3 class="inline-block">Return value:</h3>
 <%=func.ret%>
 <%elseif type(func.ret) == "table" then%>
 <h3>Return values:</h3>
@@ -47,9 +52,13 @@ end
 	<%end%>
 </ol>
 <%end%>
+</div>
+<%end%>
 
+<%if func.see then%>
+<div>
 <%if type(func.see) == "string" then %>
-<h3>See also:</h3>
+<h3 class="inline-block">See also:</h3>
 	<a href="<%=func.see%>"><%=func.see%></a>
 <%elseif type(func.see) == "table" and #func.see > 0 then %>
 <h3>See also:</h3>
@@ -61,4 +70,7 @@ end
 	<%end%>
 </ul>
 <%end%>
+</div>
+<%end%>
+
 </dd>

--- a/src/luadoc/doclet/html/luadoc.css
+++ b/src/luadoc/doclet/html/luadoc.css
@@ -2,7 +2,7 @@ body {
     margin-left: 1em; 
     margin-right: 1em; 
     font-family: arial, helvetica, geneva, sans-serif;
-	background-color:#ffffff; margin:0px;
+    background-color:#ffffff; margin:0px;
 }
 
 code {
@@ -13,7 +13,7 @@ tt {
     font-family: "Andale Mono", monospace; 
 }
 
-body, td, th { font-size: 11pt; }
+body, td, th { font-size: 1em; }
 
 h1, h2, h3, h4 { margin-left: 0em; }
 
@@ -191,6 +191,10 @@ div.header, div.footer { margin-left: 0em; }
 	background-color: #ffffff;
 }
 
+.inline-block {
+    display: inline-block;
+}
+
 @media print {
 	body { 
 		font: 12pt "Times New Roman", "TimeNR", Times, serif;
@@ -276,11 +280,13 @@ table.table_list td.summary { width: 100%; }
 
 dl.function dt {border-top: 1px solid #ccc; padding-top: 1em;}
 dl.function dd {padding-bottom: 1em;}
-dl.function h3 {padding: 0; margin: 0; font-size: medium;}
+dl.function h3 {padding: 0.5em 0em 0em 0em; margin: 0; font-size: medium;}
+dl.function dd ul { margin: 0; }
 
 dl.table dt {border-top: 1px solid #ccc; padding-top: 1em;}
 dl.table dd {padding-bottom: 1em;}
-dl.table h3 {padding: 0; margin: 0; font-size: medium;}
+dl.table h3 {padding: 0.5em 0em 0em 0em; margin: 0; font-size: medium;}
+dl.table dd ul { margin: 0; }
 
 #TODO: make module_list, file_list, function_list, table_list inherit from a list
 

--- a/src/luadoc/doclet/html/module.lp
+++ b/src/luadoc/doclet/html/module.lp
@@ -27,59 +27,10 @@
 
 <h1>Module <code><%=module_doc.name%></code></h1>
 
-<p><%=module_doc.description%></p>
-<%if module_doc.author then%>
-<p><b><%= #module_doc.author>1 and "Authors" or "Author" %>:</b>
-<table class="authors_list">
-<%for _, author in ipairs(module_doc.author) do%>
-	<tr><td class="name"><%= author %></td></tr>
-<%end%>
-</table>
-</p>
-<%end%>
-<%if module_doc.copyright then%>
-<p>Copyright&copy; <%=module_doc.copyright%></p>
-<%end%>
-<%if module_doc.release then%>
-<p><small><b>Release:</b> <%=module_doc.release%></small></p>
-<%end%>
-
-<%if #module_doc.tables > 0 then%>
-<h2>Tables</h2>
-<table class="table_list">
-<%for _, tab_name in ipairs(module_doc.tables) do%>
-	<tr>
-	<td class="name" nowrap><a href="#<%=tab_name%>"><%=tab_name%></a></td>
-	<td class="summary"><%=module_doc.tables[tab_name].summary%></td>
-	</tr>
-<%end%>
-</table>
-<%end%>
-
-<%if #module_doc.functions > 0 then%>
-<h2>Functions</h2>
-<table class="function_list">
-<%for _, func_name in ipairs(module_doc.functions) do
-  local func_data = module_doc.functions[func_name]%>
-	<tr>
-	<td class="name" nowrap><%=func_data.private and "local " or ""%><a href="#<%=func_name%>"><%=func_name%></a>&nbsp;(<%=table.concat(module_doc.functions[func_name].param, ", ")%>)</td>
-	<td class="summary"><%=module_doc.functions[func_name].summary%></td>
-	</tr>
-<%end%>
-</table>
-<%end%>
-
-<br/>
-<br/>
-
-<%if #module_doc.tables > 0 then%>
-<h2><a name="tables"></a>Tables</h2>
-<dl class="table">
-<%for _, tab_name in ipairs(module_doc.tables) do%>
-<%=luadoc.doclet.html.include("table.lp", { doc=doc, module_doc=module_doc, tab=module_doc.tables[tab_name] })%>
-<%end%>
-</dl>
-<%end%>
+<%=luadoc.doclet.html.include("module_or_file.lp", { 
+    about=module_doc,
+    functions=module_doc.functions, module_doc=module_doc, tables=module_doc.tables 
+})%>
 
 <%if #module_doc.functions > 0 then%>
 <h2><a name="functions"></a>Functions</h2>

--- a/src/luadoc/doclet/html/module.lp
+++ b/src/luadoc/doclet/html/module.lp
@@ -44,6 +44,18 @@
 <p><small><b>Release:</b> <%=module_doc.release%></small></p>
 <%end%>
 
+<%if #module_doc.tables > 0 then%>
+<h2>Tables</h2>
+<table class="table_list">
+<%for _, tab_name in ipairs(module_doc.tables) do%>
+	<tr>
+	<td class="name" nowrap><a href="#<%=tab_name%>"><%=tab_name%></a></td>
+	<td class="summary"><%=module_doc.tables[tab_name].summary%></td>
+	</tr>
+<%end%>
+</table>
+<%end%>
+
 <%if #module_doc.functions > 0 then%>
 <h2>Functions</h2>
 <table class="function_list">
@@ -57,33 +69,8 @@
 </table>
 <%end%>
 
-
-<%if #module_doc.tables > 0 then%>
-<h2>Tables</h2>
-<table class="table_list">
-<%for _, tab_name in ipairs(module_doc.tables) do%>
-	<tr>
-	<td class="name" nowrap><a href="#<%=tab_name%>"><%=tab_name%></a></td>
-	<td class="summary"><%=module_doc.tables[tab_name].summary%></td>
-	</tr>
-<%end%>
-</table>
-<%end%>
-
-
 <br/>
 <br/>
-
-
-<%if #module_doc.functions > 0 then%>
-<h2><a name="functions"></a>Functions</h2>
-<dl class="function">
-<%for _, func_name in ipairs(module_doc.functions) do%>
-<%=luadoc.doclet.html.include("function.lp", { doc=doc, module_doc=module_doc, func=module_doc.functions[func_name] })%>
-<%end%>
-</dl>
-<%end%>
-
 
 <%if #module_doc.tables > 0 then%>
 <h2><a name="tables"></a>Tables</h2>
@@ -94,6 +81,14 @@
 </dl>
 <%end%>
 
+<%if #module_doc.functions > 0 then%>
+<h2><a name="functions"></a>Functions</h2>
+<dl class="function">
+<%for _, func_name in ipairs(module_doc.functions) do%>
+<%=luadoc.doclet.html.include("function.lp", { doc=doc, module_doc=module_doc, func=module_doc.functions[func_name] })%>
+<%end%>
+</dl>
+<%end%>
 
 </div> <!-- id="content" -->
 

--- a/src/luadoc/doclet/html/module_or_file.lp
+++ b/src/luadoc/doclet/html/module_or_file.lp
@@ -1,0 +1,76 @@
+<%if about.description then%>
+<p><%=about.description%></p>
+<%end%>
+<%if about.author then%>
+<p><b><%= #about.author>1 and "Authors" or "Author" %>:</b>
+<ul class="authors_list">
+<%for _, author in ipairs(about.author) do%>
+	<li class="name"><%= author %></li>
+<%end%>
+</ul>
+</p>
+<%end%>
+<%if about.copyright then%>
+<p>Copyright &copy;<%=about.copyright%></p>
+<%end%>
+<%if about.release then%>
+<p><small><b>Release:</b> <%=about.release%></small></p>
+<%end%>
+
+<%
+if #tables > 0 then%>
+<h2>Tables</h2>
+<table class="table_list">
+<%for _, tab_name in ipairs(tables) do%>
+	<tr>
+	<td class="name" nowrap><a href="#<%=tab_name%>"><%=tab_name%></a></td>
+	<td class="summary"><%=tables[tab_name].summary%></td>
+	</tr>
+<%end%>
+</table>
+<%end%>
+
+<%
+if #functions > 0 then
+
+  fnames = { } 
+  for _, func_name in ipairs(functions) do
+      local is_method = false
+      for _, tab_name in ipairs(tables) do
+          if func_name:find('^'..tab_name..'[.:]') then
+              is_method = true
+          end
+      end
+      if not is_method then
+          table.insert(fnames,func_name)
+      end
+  end
+
+  if #fnames > 0 then%>
+    <h2>Functions</h2>
+    <table class="function_list">
+    <%for _, func_name in ipairs(fnames) do
+      local func_data = functions[func_name]%>
+	<tr>
+	<td class="name" nowrap><%=func_data.private and "local " or ""%><a href="#<%=func_name%>"><%=func_name%></a>&nbsp;(<%=table.concat(func_data.param, ", ")%>)</td>
+	<td class="summary"><%=func_data.summary%></td>
+	</tr>
+    <%end%>
+    </table>
+  <%end%>
+<%end%>
+
+<%if #tables > 0 then%>
+<h2><a name="tables"></a>Tables</h2>
+<dl class="table">
+<%for _, tab_name in ipairs(tables) do%>
+  <%if file_doc then%>
+    <%=luadoc.doclet.html.include("table.lp", { doc=doc, file_doc=file_doc, tab=tables[tab_name], functions=functions })%>
+  <%else%>
+    <%=luadoc.doclet.html.include("table.lp", { doc=doc, module_doc=module_doc, tab=tables[tab_name], functions=functions })%>
+  <%end%>
+<%end%>
+</dl>
+<%end%>
+
+

--- a/src/luadoc/doclet/html/table.lp
+++ b/src/luadoc/doclet/html/table.lp
@@ -2,7 +2,7 @@
 <dd><%=tab.description%>
 
 <%if type(tab.field) == "table" and #tab.field > 0 then%>
-<em>Fields</em>
+<h3>Fields</h3>
 <ul>
 	<%for p = 1, #tab.field do%>
 	<li>

--- a/src/luadoc/doclet/html/table.lp
+++ b/src/luadoc/doclet/html/table.lp
@@ -11,7 +11,8 @@
 	<%end%>
 </ul>
 <%end%>
-<%if type(tab.field) == "table" and type(functions) == "table" then
+
+<%if type(functions) == "table" then
     methods = {}
     for _, func_name in ipairs(functions) do
         if func_name:find( '^'..tab.name ) then

--- a/src/luadoc/doclet/html/table.lp
+++ b/src/luadoc/doclet/html/table.lp
@@ -7,9 +7,28 @@
 	<%for p = 1, #tab.field do%>
 	<li>
 	  <%=tab.field[p]%>: <%=tab.field[tab.field[p]] or ""%>
-	</li>
+        </li>
 	<%end%>
 </ul>
+<%end%>
+<%if type(tab.field) == "table" and type(functions) == "table" then
+    methods = {}
+    for _, func_name in ipairs(functions) do
+        if func_name:find( '^'..tab.name ) then
+            table.insert(methods,func_name)
+        end
+    end%>    
+   <%if #methods > 0 then%>
+      <h3>Methods</h3>
+      <ul>
+        <%for _,m in ipairs(methods) do%>
+        <li>
+           <a href="#<%=m%>"><%=m%></a>
+           <%=functions[m].summary %>
+        </li>
+        <%end%>
+      </ul>
+   <%end%>
 <%end%>
 
 </dd>

--- a/src/luadoc/taglet/standard.lua
+++ b/src/luadoc/taglet/standard.lua
@@ -149,9 +149,11 @@ end
 -------------------------------------------------------------------------------
 -- Parses the information inside a block comment
 -- @param block block with comment field
+-- @param modulename module already found, if any
 -- @return block parameter
+-- @return modulename if found or given
 
-local function parse_comment (block, first_line)
+local function parse_comment (block, first_line, modulename)
 
 	-- get the first non-empty line of code
 	local code = table.foreachi(block.code, function(_, line)
@@ -181,6 +183,7 @@ local function parse_comment (block, first_line)
 			block.class = "module"
 			block.name = module_name
 			block.param = {}
+                        modulename = module_name
 		else
 			block.param = {}
 		end
@@ -215,7 +218,10 @@ local function parse_comment (block, first_line)
 	block.summary = parse_summary(block.description)
 	assert(string.sub(block.description, 1, 1) ~= " ", string.format("`%s'", block.description))
 	
-	return block
+        if not modulename and block.class == "module" then
+            modulename = block.name
+        end
+	return block, modulename
 end
 
 -------------------------------------------------------------------------------
@@ -241,7 +247,7 @@ local function parse_block (f, line, modulename, first)
 			line, block.code, modulename = parse_code(f, line, modulename)
 			
 			-- parse information in block comment
-			block = parse_comment(block, first)
+			block, modulename = parse_comment(block, first, modulename)
 
 			return line, block, modulename
 		else
@@ -252,7 +258,7 @@ local function parse_block (f, line, modulename, first)
 	-- reached end of file
 	
 	-- parse information in block comment
-	block = parse_comment(block, first)
+	block, modulename = parse_comment(block, first, modulename)
 	
 	return line, block, modulename
 end

--- a/src/luadoc/taglet/standard/tags.lua
+++ b/src/luadoc/taglet/standard/tags.lua
@@ -62,10 +62,10 @@ end
 -- an error and do not change the previous value
 
 local function name (tag, block, text)
+        text = text:gsub("%s+$","") -- right trim name
 	if block[tag] and block[tag] ~= text then
 		luadoc.logger:error(string.format("block name conflict: `%s' -> `%s'", block[tag], text))
 	end
-	
 	block[tag] = text
 end
 


### PR DESCRIPTION
As someone already noted in 2008 http://lists.luaforge.net/pipermail/kepler-project/2008-June/002731.html LuaDoc does not work as assumed if you only use the "@class module" tag, but not the "module" statement, which now seems to be deprecated. I tried to patch LuaDoc, maybe you'd like to have a look. In the CSS you should not mix absolute font size (11pt) and relative font sizes (em). Cheers!
