### PR TITLE
Update project links from luaforge to github pages

### DIFF
--- a/doc/us/architecture.html
+++ b/doc/us/architecture.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><a href="examples.html">Examples</a></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><a href="license.html">License</a></li>

--- a/doc/us/examples.html
+++ b/doc/us/examples.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><strong>Examples</strong></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><a href="license.html">License</a></li>

--- a/doc/us/index.html
+++ b/doc/us/index.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><a href="examples.html">Examples</a></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><a href="license.html">License</a></li>

--- a/doc/us/license.html
+++ b/doc/us/license.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><a href="examples.html">Examples</a></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><strong>License</strong></li>

--- a/doc/us/manual.html
+++ b/doc/us/manual.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><a href="examples.html">Examples</a></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><a href="license.html">License</a></li>


### PR DESCRIPTION
The current links to luaforge either result in 404 pages or redirect to http://keplerproject.github.io/luadoc
