### PR TITLE
Use GitHub links instead of luaforge links

### DIFF
--- a/architecture.html
+++ b/architecture.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><a href="examples.html">Examples</a></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><a href="license.html">License</a></li>

--- a/examples.html
+++ b/examples.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><strong>Examples</strong></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><a href="license.html">License</a></li>

--- a/index.html
+++ b/index.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><a href="examples.html">Examples</a></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><a href="license.html">License</a></li>

--- a/license.html
+++ b/license.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><a href="examples.html">Examples</a></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><strong>License</strong></li>

--- a/manual.html
+++ b/manual.html
@@ -52,10 +52,10 @@
 			</ul>
 		</li>
 		<li><a href="examples.html">Examples</a></li>
-        <li><a href="http://luaforge.net/projects/luadoc/">Project</a>
+        <li><a href="https://github.com/keplerproject/luadoc">Project</a>
             <ul>
-                <li><a href="http://luaforge.net/tracker/?group_id=18">Bug Tracker</a></li>
-                <li><a href="http://luaforge.net/scm/?group_id=18">CVS</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/issues">Bug Tracker</a></li>
+                <li><a href="https://github.com/keplerproject/luadoc/tree/master">CVS</a></li>
             </ul>
         </li>
 		<li><a href="license.html">License</a></li>


### PR DESCRIPTION
The current links to luaforge CVS and issue tracker lead to 404 error pages or redirect to http://keplerproject.github.io/luadoc
